### PR TITLE
Remove persistent active tab

### DIFF
--- a/packages/frontapp/src/app/components/NavbarItem/index.tsx
+++ b/packages/frontapp/src/app/components/NavbarItem/index.tsx
@@ -8,6 +8,7 @@ import { NavbarItems } from '../../../utils/NavbarItems';
 import { useAppDispatch } from '../../hooks/useTypedDispatch';
 import { logout } from '../../store/slices/userSlice';
 import { RolesTypes } from '@mimir/global-types';
+import { resetTab } from '../../store/slices/tabsSlice';
 
 interface IProps {
   icon: ReactElement;
@@ -91,6 +92,7 @@ const NavbarItem: FC<IProps> = ({ icon, name, path, changeActiveTab }) => {
 
   const handleLogout = () => {
     dispatch(logout());
+    dispatch(resetTab());
     history('/');
     localStorage.clear();
   };

--- a/packages/frontapp/src/app/store/index.ts
+++ b/packages/frontapp/src/app/store/index.ts
@@ -21,7 +21,7 @@ const persistConfig = {
   storage,
   migrate: createMigrate(migrations, { debug: true }),
   stateReconciler: autoMergeLevel2,
-  whitelist: ['tabs', 'user'],
+  whitelist: ['user'],
 };
 
 const persistedReducer = persistReducer<RootReducer>(

--- a/packages/frontapp/src/app/store/slices/tabsSlice.ts
+++ b/packages/frontapp/src/app/store/slices/tabsSlice.ts
@@ -16,8 +16,11 @@ const tabsSlice = createSlice({
     setActiveTab: (state: IStateTabs, action: PayloadAction<string | null>) => {
       state.activeTab = action.payload;
     },
+    resetTab: (state: IStateTabs) => {
+      state.activeTab = NavbarItems.HOME;
+    },
   },
 });
 
-export const { setActiveTab } = tabsSlice.actions;
+export const { setActiveTab, resetTab } = tabsSlice.actions;
 export default tabsSlice.reducer;


### PR DESCRIPTION
Closes #533 
- removed `tab` slice from redux-persist
- added resetting tab on logout (the tab could be the same even between users with different roles)