### PR TITLE
Make category link on item page work

### DIFF
--- a/packages/frontapp/src/app/components/BookInfo/DescriptionBook.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/DescriptionBook.tsx
@@ -14,6 +14,7 @@ import { INewData, Location, OpenLink, TitleHolder, Topic } from './index';
 import { toast } from 'react-toastify';
 import { useMediaQuery } from 'react-responsive';
 import Days from './Days';
+import { RoutesTypes } from '../../../utils/routes';
 
 export const WrapperInfo = styled.div`
   display: flex;
@@ -222,7 +223,9 @@ const DescriptionBook: FC<IDescriptionBook> = ({
         )}
         {!editing && <Topic>Genre: </Topic>}
         {userRole === RolesTypes.READER ? (
-          <OpenLink>{category || 'Genres of book'}</OpenLink>
+          <OpenLink to={`${RoutesTypes.CATEGORY}?categories=${category || ''}`}>
+            {category || 'Genres of book'}
+          </OpenLink>
         ) : editing ? (
           <WrapperDropDown>
             <TitleHolder>Genre </TitleHolder>

--- a/packages/frontapp/src/app/components/BookInfo/DescriptionBook.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/DescriptionBook.tsx
@@ -15,6 +15,7 @@ import { toast } from 'react-toastify';
 import { useMediaQuery } from 'react-responsive';
 import Days from './Days';
 import { RoutesTypes } from '../../../utils/routes';
+import { t } from 'i18next';
 
 export const WrapperInfo = styled.div`
   display: flex;
@@ -208,7 +209,7 @@ const DescriptionBook: FC<IDescriptionBook> = ({
       <ShortDescription>
         {editing ? (
           <>
-            <TitleHolder>Name </TitleHolder>
+            <TitleHolder>{t('DonateItem.Inputs.Name.Title')}</TitleHolder>
             <WrapperInput isFullWidth={isPhone || isLaptop}>
               <StyledInput
                 type="text"
@@ -221,14 +222,14 @@ const DescriptionBook: FC<IDescriptionBook> = ({
         ) : (
           <TitleBook>{title || 'Book Title'}</TitleBook>
         )}
-        {!editing && <Topic>Genre: </Topic>}
+        {!editing && <Topic>{t('DonateItem.Inputs.Genre.Title')}: </Topic>}
         {userRole === RolesTypes.READER ? (
           <OpenLink to={`${RoutesTypes.CATEGORY}?categories=${category || ''}`}>
             {category || 'Genres of book'}
           </OpenLink>
         ) : editing ? (
           <WrapperDropDown>
-            <TitleHolder>Genre </TitleHolder>
+            <TitleHolder>{t('DonateItem.Inputs.Genre.Title')}</TitleHolder>
             <RestyledDropdown
               options={listOfGenres}
               initIndex={currentGenreIndex}
@@ -242,7 +243,7 @@ const DescriptionBook: FC<IDescriptionBook> = ({
         {editing ? (
           <>
             <br />
-            <TitleHolder>Author </TitleHolder>
+            <TitleHolder>{t('DonateItem.Inputs.Author.Title')}</TitleHolder>
             <WrapperInput isFullWidth={isPhone || isLaptop}>
               <StyledInput
                 type="text"
@@ -254,13 +255,13 @@ const DescriptionBook: FC<IDescriptionBook> = ({
           </>
         ) : (
           <>
-            <Topic>Author: </Topic>
+            <Topic>{t('DonateItem.Inputs.Author.Title')}: </Topic>
             <TopicDescription>{author || 'Author Name'}</TopicDescription>
           </>
         )}
         {userRole === RolesTypes.READER ? (
           <>
-            <Topic>State: </Topic>
+            <Topic>{t('DonateItem.Inputs.State')}: </Topic>
             <StyledStatus>
               <BookStatus
                 fontSize={dimensions.base}
@@ -272,7 +273,7 @@ const DescriptionBook: FC<IDescriptionBook> = ({
         ) : editing ? (
           <>
             <br />
-            <TitleHolder>Deadline </TitleHolder>
+            <TitleHolder>{t('DonateItem.Inputs.Deadline')} </TitleHolder>
             <DeadlineInputWrapper>
               <StyledInputDeadline
                 value={newDeadline}
@@ -286,7 +287,7 @@ const DescriptionBook: FC<IDescriptionBook> = ({
           </>
         ) : (
           <>
-            <Topic>Deadline: </Topic>
+            <Topic>{t('DonateItem.Inputs.Deadline')}: </Topic>
             <TopicDescription>
               {newDeadline + ' '}
               <Days number={newDeadline} />
@@ -296,7 +297,9 @@ const DescriptionBook: FC<IDescriptionBook> = ({
         <>
           {editing ? (
             <WrapperDropDown>
-              <TitleHolder>Location </TitleHolder>
+              <TitleHolder>
+                {t('DonateItem.Inputs.Location.Title')}{' '}
+              </TitleHolder>
               <RestyledDropdown
                 options={allLocations!.getAllLocations.map((loc) => ({
                   id: loc!.id,
@@ -310,7 +313,7 @@ const DescriptionBook: FC<IDescriptionBook> = ({
             </WrapperDropDown>
           ) : (
             <>
-              <Topic>Location: </Topic>
+              <Topic>{t('DonateItem.Inputs.Location.Title')}: </Topic>
               <TopicDescription>{location.location}</TopicDescription>
             </>
           )}

--- a/packages/frontapp/src/app/components/BookInfo/ReturnBookButtons.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/ReturnBookButtons.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { StyledButton } from './index';
 import { ReactComponent as Claim } from '../../../assets/claim.svg';
+import { t } from 'i18next';
 
 interface IControl {
   isClaimed?: boolean;
@@ -18,7 +19,7 @@ export const ReturnBookButtons: FC<IControl> = ({
   if (!isClaimed)
     return (
       <StyledButton
-        value="Claim a book"
+        value={t('DonateItem.Buttons.Claim')}
         onClick={onClaim}
         svgComponent={<Claim />}
       />
@@ -26,9 +27,9 @@ export const ReturnBookButtons: FC<IControl> = ({
 
   return (
     <>
-      <StyledButton value="Return a book" onClick={onReturn} />
+      <StyledButton value={t('DonateItem.Buttons.Return')} onClick={onReturn} />
       <StyledButton
-        value="Extend claim period"
+        value={t('DonateItem.Buttons.Extend')}
         onClick={onProlong}
         transparent
       />

--- a/packages/frontapp/src/app/components/BookInfo/__snapshots__/DescriptionBook.spec.tsx.snap
+++ b/packages/frontapp/src/app/components/BookInfo/__snapshots__/DescriptionBook.spec.tsx.snap
@@ -158,7 +158,7 @@ exports[`render DescriptionBook component renders correctly with snapshots 1`] =
     <p
       class="emotion-4"
     >
-      Genre: 
+      : 
     </p>
     <a
       class="emotion-5"
@@ -169,7 +169,7 @@ exports[`render DescriptionBook component renders correctly with snapshots 1`] =
     <p
       class="emotion-4"
     >
-      Author: 
+      : 
     </p>
     <p
       class="emotion-7"
@@ -179,7 +179,7 @@ exports[`render DescriptionBook component renders correctly with snapshots 1`] =
     <p
       class="emotion-4"
     >
-      State: 
+      : 
     </p>
     <div
       class="emotion-9"
@@ -199,7 +199,7 @@ exports[`render DescriptionBook component renders correctly with snapshots 1`] =
     <p
       class="emotion-4"
     >
-      Location: 
+      : 
     </p>
     <p
       class="emotion-7"

--- a/packages/frontapp/src/app/components/BookInfo/__snapshots__/DescriptionBook.spec.tsx.snap
+++ b/packages/frontapp/src/app/components/BookInfo/__snapshots__/DescriptionBook.spec.tsx.snap
@@ -162,6 +162,7 @@ exports[`render DescriptionBook component renders correctly with snapshots 1`] =
     </p>
     <a
       class="emotion-5"
+      href="/category?categories=Fantasy"
     >
       Fantasy
     </a>

--- a/packages/frontapp/src/app/components/BookInfo/index.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/index.tsx
@@ -31,7 +31,7 @@ import {
 import { useAppSelector } from '../../hooks/useTypedSelector';
 import ErrorMessage from '../ErrorMessge';
 import AskManagerForm from '../AskManagerForm';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { RolesTypes } from '@mimir/global-types';
 import { IDropdownOption } from '../Dropdown';
 import { TUserLocation } from '../../store/slices/userSlice';
@@ -137,7 +137,7 @@ const TextAreaWrapper = styled.div`
   }
 `;
 
-export const OpenLink = styled.a`
+export const OpenLink = styled(Link)`
   cursor: pointer;
   margin: ${dimensions.xs_2} 0;
   font-weight: 300;

--- a/packages/frontapp/src/app/components/BookInfo/index.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/index.tsx
@@ -43,6 +43,7 @@ import { ReturnBookButtons } from './ReturnBookButtons';
 import { NotifyMeButtons } from './NotifyMeButtons';
 import { EditButtons } from './EditButtons';
 import { ControlButtons } from './ControlButtons';
+import { t } from 'i18next';
 
 export const BookHolder = styled.div`
   width: 100%;
@@ -524,7 +525,9 @@ const BookInfo: FC<IBookInfoProps> = ({
         {editing ? (
           <>
             <br />
-            <TitleHolder>Description: </TitleHolder>
+            <TitleHolder>
+              {t('DonateItem.Inputs.Description.Title')}:
+            </TitleHolder>
             <TextAreaWrapper>
               <StyledTextArea
                 value={newDescription}
@@ -533,7 +536,7 @@ const BookInfo: FC<IBookInfoProps> = ({
             </TextAreaWrapper>
           </>
         ) : description ? (
-          <Section title={'Description: '}>
+          <Section title={t('DonateItem.Inputs.Description.Title')}>
             <ExpandableText>{description}</ExpandableText>
           </Section>
         ) : null}

--- a/packages/frontapp/src/app/components/BookInfo/index.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/index.tsx
@@ -585,8 +585,8 @@ const BookInfo: FC<IBookInfoProps> = ({
       <Modal active={isShowSuccessClaim} setActive={setIsShowSuccessClaim}>
         <SuccessMessage
           setActive={setIsShowSuccessClaim}
-          title="You have successfully claim the book"
-          description="Enjoy reading and don't forget to return this by"
+          title={t('DonateItem.Messages.Claim.Title')}
+          description={t('DonateItem.Messages.Claim.Description')}
           created_at={dateConditionOfClaiming}
         />
       </Modal>
@@ -595,9 +595,9 @@ const BookInfo: FC<IBookInfoProps> = ({
         setActive={setIsShowErrorMessageOfClaiming}
       >
         <ErrorMessage
-          title="Something goes wrong with your claiming"
+          title={t('DonateItem.Messages.Errors.Claim')}
           message={errorConditionOfClaiming}
-          titleCancel="Ask a manager"
+          titleCancel={t('DonateItem.Buttons.AskManager')}
           setActive={setIsShowErrorMessageOfClaiming}
           onClick={showAskManagerModal}
         />
@@ -605,15 +605,15 @@ const BookInfo: FC<IBookInfoProps> = ({
       <Modal active={isShowSuccessReturn} setActive={setIsSuccessReturn}>
         <SuccessMessage
           setActive={setIsSuccessReturn}
-          title="You have successfully return the book"
+          title={t('DonateItem.Messages.Return')}
         />
       </Modal>
       <Modal active={isShowSuccessExtend} setActive={setIsSuccessExtend}>
         <SuccessMessage
           setActive={setIsSuccessExtend}
           created_at={dateConditionOfExtending}
-          title="You have successfully extend claim period"
-          description="Enjoy reading and don't forget to return this by"
+          title={t('DonateItem.Messages.Extend.Title')}
+          description={t('DonateItem.Messages.Extend.Description')}
         />
       </Modal>
       <Modal
@@ -621,18 +621,18 @@ const BookInfo: FC<IBookInfoProps> = ({
         setActive={setIsShowErrorMessageOfExtending}
       >
         <ErrorMessage
-          title="Something goes wrong with your extending"
+          title={t('DonateItem.Messages.Errors.Extend')}
           message={errorConditionOfExtending}
           setActive={setIsShowErrorMessageOfExtending}
-          titleCancel="Close"
+          titleCancel={t('DonateItem.Messages.Buttons.Cancel')}
         />
       </Modal>
       <Modal active={isReturnError} setActive={setIsReturnError}>
         <ErrorMessage
-          title="Something goes wrong with your returning"
+          title={t('DonateItem.Messages.Errors.Return')}
           message={ReturningBookError}
           setActive={setIsReturnError}
-          titleCancel="Close"
+          titleCancel={t('DonateItem.Messages.Buttons.Close')}
         />
       </Modal>
       <Modal active={isShowAskManger} setActive={setIsShowAskManager}>
@@ -648,32 +648,32 @@ const BookInfo: FC<IBookInfoProps> = ({
         setActive={setIsShowWindowReportedToManager}
       >
         <ErrorMessage
-          title="We reported the problem to the manager"
-          message="The problem will be solved soon"
+          title={t('DonateItem.Messages.Errors.ReportToManager.Title')}
+          message={t('DonateItem.Messages.Errors.ReportToManager.Description')}
           setActive={setIsShowWindowReportedToManager}
-          titleCancel="Close"
+          titleCancel={t('DonateItem.Messages.Buttons.Close')}
           onClick={closeReportedManager}
         />
       </Modal>
       {currentStatus === 'Free' ? (
         <Modal active={deleteWarning} setActive={setDeleteWarning}>
           <ErrorMessage
-            title="Warning"
-            message={`Are you sure you want to delete the book "${title}" from the library permanently?`}
+            title={t('DonateItem.Messages.Delete.Title')}
+            message={t('DonateItem.Messages.Delete.Desctription', title)}
             setActive={setDeleteWarning}
-            titleCancel="Cancel"
-            titleOption="Yes, delete"
+            titleCancel={t('DonateItem.Messages.Buttons.Cancel')}
+            titleOption={t('DonateItem.Messages.Buttons.Delete')}
             onSubmitClick={deleteItem}
           />
         </Modal>
       ) : (
         <Modal active={deleteWarning} setActive={setDeleteWarning}>
           <ErrorMessage
-            title="Warning"
-            message={`The book "${title}" is now in the possession of a person with Id ${statusInfo?.person_id} .Are you sure you want to delete the book "${title}" from the library permanently?`}
+            title={t('DonateItem.Messages.Delete.Title')}
+            message={t('DonateItem.Messages.Errors.Delete.Desctription', title)}
             setActive={setDeleteWarning}
-            titleCancel="Cancel"
-            titleOption="Yes, delete"
+            titleCancel={t('DonateItem.Messages.Buttons.Cancel')}
+            titleOption={t('DonateItem.Messages.Buttons.Delete')}
             onSubmitClick={deleteItem}
           />
         </Modal>

--- a/packages/frontapp/src/app/components/BookInfo/index.tsx
+++ b/packages/frontapp/src/app/components/BookInfo/index.tsx
@@ -170,7 +170,7 @@ export interface INewData {
 }
 
 export interface IBookInfoProps {
-  person_id: number | undefined;
+  person_id?: number | undefined;
   src: string | null | undefined;
   title: string | undefined;
   description: string | undefined;
@@ -196,7 +196,6 @@ const BookInfo: FC<IBookInfoProps> = ({
   created_at,
   updated_at,
   material_id,
-  person_id,
   type,
   location,
 }) => {
@@ -244,8 +243,6 @@ const BookInfo: FC<IBookInfoProps> = ({
 
   const [newDescription, setNewDescription] = useState(description || '');
   const [deleteWarning, setDeleteWarning] = useState(false);
-  const [isMaterialTakenByCurrentUser, setIsMaterialTakenByCurrentUser] =
-    useState(false);
 
   const handleChangeDescription = (
     e: React.ChangeEvent<HTMLTextAreaElement>
@@ -324,7 +321,6 @@ const BookInfo: FC<IBookInfoProps> = ({
     });
     setValueIsISBN('');
     setIsShowClaimModal(false);
-    setIsMaterialTakenByCurrentUser(true);
   };
 
   const retrieveBook = async () => {
@@ -424,7 +420,6 @@ const BookInfo: FC<IBookInfoProps> = ({
       )
     ) {
       //TODO: consider removing this local book claiming if no material_id provided
-      setIsMaterialTakenByCurrentUser(true);
     }
   }, [getNotificationsByPersonData]);
 
@@ -450,7 +445,6 @@ const BookInfo: FC<IBookInfoProps> = ({
         },
       },
     });
-    setIsMaterialTakenByCurrentUser(true);
   };
 
   const handleCancelNotifyButton = async () => {
@@ -462,7 +456,6 @@ const BookInfo: FC<IBookInfoProps> = ({
         },
       },
     });
-    setIsMaterialTakenByCurrentUser(false);
   };
 
   return (
@@ -667,6 +660,7 @@ const BookInfo: FC<IBookInfoProps> = ({
           />
         </Modal>
       ) : (
+        // Here, I removed the person_id from the message. Later we can add username if needed
         <Modal active={deleteWarning} setActive={setDeleteWarning}>
           <ErrorMessage
             title={t('DonateItem.Messages.Delete.Title')}

--- a/packages/frontapp/src/app/components/DonateBook/index.tsx
+++ b/packages/frontapp/src/app/components/DonateBook/index.tsx
@@ -546,7 +546,7 @@ const DonateBook: FC<IPropsDonateBook> = ({ data, onHideContent }) => {
           </FormWrapper>
           <WrapperButtons>
             <StyledButton
-              value={t(`DonateItem.Button.AddItem`)}
+              value={t(`DonateItem.Buttons.AddItem`)}
               disabled={isInvalid}
               type="submit"
             />
@@ -557,7 +557,7 @@ const DonateBook: FC<IPropsDonateBook> = ({ data, onHideContent }) => {
             />
             {userRole !== RolesTypes.MANAGER && (
               <StyledButton
-                value={t(`DonateItem.Button.AskManager`)}
+                value={t(`DonateItem.Buttons.AskManager`)}
                 transparent
                 onClick={handleShowAskManagerForm}
               />

--- a/packages/frontapp/src/app/components/ExpandableText/index.tsx
+++ b/packages/frontapp/src/app/components/ExpandableText/index.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from 'react';
-import { OpenLink } from '../BookInfo';
 import styled from '@emotion/styled';
 import { colors, dimensions } from '@mimir/ui-kit';
 
@@ -15,6 +14,19 @@ export const Description = styled.p<{ showFullDescription: boolean }>`
   color: ${colors.main_black};
 `;
 
+export const OpenButton = styled.button`
+  border: none;
+  background: none;
+  margin: ${dimensions.xs_2} 0;
+  padding: 0;
+  font-weight: 300;
+  color: ${colors.accent_color};
+  font-size: ${dimensions.base};
+  line-height: ${dimensions.xl};
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
 interface IProps {
   children: React.ReactNode;
 }
@@ -27,9 +39,9 @@ const ExpandableText: FC<IProps> = ({ children }) => {
       <Description showFullDescription={showDescription}>
         {children}
       </Description>
-      <OpenLink onClick={() => setShowDescription(!showDescription)}>
+      <OpenButton onClick={() => setShowDescription(!showDescription)}>
         {!showDescription ? 'see full description' : 'hide description'}
-      </OpenLink>
+      </OpenButton>
     </>
   );
 };

--- a/packages/frontapp/src/app/components/ExpandableText/index.tsx
+++ b/packages/frontapp/src/app/components/ExpandableText/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import styled from '@emotion/styled';
 import { colors, dimensions } from '@mimir/ui-kit';
+import { t } from 'i18next';
 
 export const Description = styled.p<{ showFullDescription: boolean }>`
   overflow: ${(props) => (props.showFullDescription ? 'visible' : 'hidden')};
@@ -40,7 +41,9 @@ const ExpandableText: FC<IProps> = ({ children }) => {
         {children}
       </Description>
       <OpenButton onClick={() => setShowDescription(!showDescription)}>
-        {!showDescription ? 'see full description' : 'hide description'}
+        {!showDescription
+          ? t('DonateItem.ExpandDescription.Show')
+          : t('DonateItem.ExpandDescription.Hide')}
       </OpenButton>
     </>
   );

--- a/packages/frontapp/src/app/pages/BookPreview.tsx
+++ b/packages/frontapp/src/app/pages/BookPreview.tsx
@@ -194,7 +194,6 @@ const BookPreview = ({ donate }: BookPreviewProps) => {
         <>
           {data?.getMaterialById && (
             <BookInfo
-              person_id={id}
               identifier={data.getMaterialById.identifier}
               src={data?.getMaterialById.picture}
               title={data?.getMaterialById.title}

--- a/packages/localization/src/lib/resources.ts
+++ b/packages/localization/src/lib/resources.ts
@@ -305,6 +305,40 @@ export const resources = {
           Return: 'Return a book',
           Extend: 'Extend claim period',
         },
+        Messages: {
+          Errors: {
+            Claim: 'Something goes wrong with your claiming',
+            Extend: 'Something goes wrong with your extending',
+            Return: 'Something goes wrong with your returning',
+            ReportToManager: {
+              Title: 'We reported the problem to the manager',
+              Description: 'The problem will be solved soon',
+            },
+            Delete: {
+              Title: 'Warning',
+              Desctription: `The book {{title}} is now in the possession of a person. Are you sure you want to delete the book {{title}} from the library permanently?`,
+            },
+          },
+          Claim: {
+            Title: 'You have successfully claim the book',
+            Description: "Enjoy reading and don't forget to return this by",
+          },
+          Extend: {
+            Title: 'You have successfully extended claim period',
+            Description: "Enjoy reading and don't forget to return this by",
+          },
+          Return: 'You have successfully returned the book',
+          Delete: {
+            Title: 'Warning',
+            Desctription:
+              'Are you sure you want to delete the book {{title}} from the library permanently?',
+          },
+          Buttons: {
+            Delete: 'Yes, delete',
+            Cancel: 'Cancel',
+            Close: 'Close',
+          },
+        },
       },
       ManagerDonateModal: {
         Title: 'Warning!',
@@ -640,6 +674,40 @@ export const resources = {
           Claim: 'Забронировать книгу',
           Return: 'Вернуть книгу',
           Extend: 'Продлить период использования',
+        },
+        Messages: {
+          Errors: {
+            Claim: 'Что-то не так во время бронирования',
+            Extend: 'Что-то не так во время продления',
+            Return: 'Что-то не так во время возвращения',
+            ReportToManager: {
+              Title: 'Мы сообщили об ошибке менеджеру',
+              Description: 'Проблема будет решена в скором времени',
+            },
+            Delete: {
+              Title: 'Предупреждение',
+              Desctription: `Книга {{title}} сейчас находится у человека. Вы уверены, что хотите удалить книгу {{title}} из библиотеки навсегда?`,
+            },
+          },
+          Claim: {
+            Title: 'Вы успешно забронировали книгу',
+            Description: 'Наслаждайтесь чтением и не забудьте вернуть книгу к',
+          },
+          Extend: {
+            Title: 'Вы успешно продлили период использования книги',
+            Description: 'Наслаждайтесь чтением и не забудьте вернуть книгу к',
+          },
+          Return: 'Вы успешно вернули книгу',
+          Delete: {
+            Title: 'Предупреждение',
+            Desctription:
+              'Вы уверены, что хотите удалить книгу {{title}} из библиотеки навсегда?',
+          },
+          Buttons: {
+            Delete: 'Да, удалить',
+            Cancel: 'Выйти',
+            Close: 'Закрыть',
+          },
         },
       },
       ManagerDonateModal: {

--- a/packages/localization/src/lib/resources.ts
+++ b/packages/localization/src/lib/resources.ts
@@ -274,6 +274,12 @@ export const resources = {
             Title: 'Description',
             Placeholder: 'Enter book description',
           },
+          State: 'State',
+          Deadline: 'Deadline',
+        },
+        ExpandDescription: {
+          Show: 'see full description',
+          Hide: 'hide description',
         },
         Modal: {
           ISBNError: {
@@ -292,9 +298,12 @@ export const resources = {
             Message: 'The problem will be solved soon',
           },
         },
-        Button: {
+        Buttons: {
           AddItem: 'Add item to library',
           AskManager: 'Ask a manager',
+          Claim: 'Claim a book',
+          Return: 'Return a book',
+          Extend: 'Extend claim period',
         },
       },
       ManagerDonateModal: {
@@ -601,6 +610,12 @@ export const resources = {
             Title: 'Описание',
             Placeholder: 'Введите описание книги',
           },
+          State: 'Статус',
+          Deadline: 'Срок возвращения',
+        },
+        ExpandDescription: {
+          Show: 'показать описание',
+          Hide: 'скрыть описание',
         },
         Modal: {
           ISBNError: {
@@ -619,9 +634,12 @@ export const resources = {
             Message: 'Проблема будет решена в ближайшее время',
           },
         },
-        Button: {
+        Buttons: {
           AddItem: 'Добавить в библиотеку',
           AskManager: 'Спросить у менеджера',
+          Claim: 'Забронировать книгу',
+          Return: 'Вернуть книгу',
+          Extend: 'Продлить период использования',
         },
       },
       ManagerDonateModal: {

--- a/packages/localization/src/lib/resources.ts
+++ b/packages/localization/src/lib/resources.ts
@@ -320,7 +320,7 @@ export const resources = {
             },
           },
           Claim: {
-            Title: 'You have successfully claim the book',
+            Title: 'You have successfully claimed the book',
             Description: "Enjoy reading and don't forget to return this by",
           },
           Extend: {

--- a/packages/localization/src/lib/resources.ts
+++ b/packages/localization/src/lib/resources.ts
@@ -316,7 +316,7 @@ export const resources = {
             },
             Delete: {
               Title: 'Warning',
-              Desctription: `The book {{title}} is now in the possession of a person. Are you sure you want to delete the book {{title}} from the library permanently?`,
+              Desctription: `The book {{title}} is now in the possession of a person {{userName}}. Are you sure you want to delete the book {{title}} from the library permanently?`,
             },
           },
           Claim: {


### PR DESCRIPTION
Closes #602 
- made category link navigate to its category
- made `see`/`hide` button a button rather than link (semantic)
- add localization to item page (also, here I fixed the `person_id` issue with just removing it from the message)