### PR TITLE
fix deleting materials is not working #621

### DIFF
--- a/packages/apiserver/src/resources/materials/material.resolver.ts
+++ b/packages/apiserver/src/resources/materials/material.resolver.ts
@@ -105,17 +105,8 @@ export class MaterialResolver {
   async removeMaterial(
     @Args('input') removeMaterialInput: RemoveMaterialInput
   ) {
-    try {
-      const identifier = removeMaterialInput.identifier;
-      const material = await Material.findOne({
-        where: { identifier },
-      });
-      await Status.delete({ material_id: material.id });
-      await Material.remove({ ...material } as Material);
-      return material;
-    } catch (e) {
-      throw new BadRequestException();
-    }
+    const identifier = removeMaterialInput.identifier;
+    return await this.materialService.deleteMaterial(identifier);
   }
 
   @Mutation(() => Material)

--- a/packages/apiserver/src/resources/materials/material.service.ts
+++ b/packages/apiserver/src/resources/materials/material.service.ts
@@ -140,4 +140,16 @@ export class MaterialService {
       throw new GraphQLError(e.message);
     }
   }
+
+  public async deleteMaterial(identifier: string): Promise<Material> {
+    return this.connection.transaction(async (manager) => {
+      const material: Material = await manager.findOne(Material, {
+        where: { identifier },
+      });
+      await manager.update(Material, material.id, { currentStatusId: null });
+      await manager.delete(Status, { material_id: material.id });
+      await manager.remove(Material, material);
+      return material;
+    });
+  }
 }


### PR DESCRIPTION
Deleting didn't work because of the circular foreign key references:
Material.current_status_id -> staus.material_id
How I fixed it:
1. Set current_status_id foreign key to null before deleting
2. Wrapped the whole operation in transaction and moved the method to the service
3. Removed useless BadRequestException

Closes #621 