### PR TITLE
Invalidate query on donates page when donating

### DIFF
--- a/packages/frontapp/src/app/components/DonateBook/index.tsx
+++ b/packages/frontapp/src/app/components/DonateBook/index.tsx
@@ -4,6 +4,8 @@ import { toast } from 'react-toastify';
 import Dropdown, { IDropdownOption } from '../Dropdown';
 import { colors, dimensions } from '@mimir/ui-kit';
 import {
+  GetAllDonatedMaterialsByPersonDocument,
+  GetAllMaterialsDocument,
   GetMaterialFromMetadataQuery,
   useDonateBookMutation,
 } from '@mimir/apollo-client';
@@ -316,7 +318,12 @@ const DonateBook: FC<IPropsDonateBook> = ({ data, onHideContent }) => {
     title: '',
   });
 
-  const [donateBook, { error, data: donateData }] = useDonateBookMutation();
+  const [donateBook, { error, data: donateData }] = useDonateBookMutation({
+    refetchQueries: [
+      GetAllDonatedMaterialsByPersonDocument,
+      GetAllMaterialsDocument,
+    ],
+  });
 
   const isInvalid =
     !dataOfBook.author ||


### PR DESCRIPTION
closes #603 
- invalidated query on donates page when donating so it will be refetch after each donation 
- also, invalidated query for gettting all material as currently with `donatebook` method we can also add a book to the library (if it was a manager)