### PR TITLE
Update files' migration service to copy files from 3rd party resource…

### DIFF
--- a/packages/apiserver/src/migrations/1677047756264-addOriginalPictureColumn.ts
+++ b/packages/apiserver/src/migrations/1677047756264-addOriginalPictureColumn.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const COLUMN_NAME = 'original_picture';
+
+export class addOriginalPictureColumn1677047756264
+  implements MigrationInterface
+{
+  name = 'addOriginalPictureColumn1677047756264';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "material" ADD COLUMN "${COLUMN_NAME}" CHARACTER VARYING`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "material" DROP COLUMN "${COLUMN_NAME}"`
+    );
+  }
+}

--- a/packages/apiserver/src/resources/materials/material.entity.ts
+++ b/packages/apiserver/src/resources/materials/material.entity.ts
@@ -38,6 +38,9 @@ export class Material extends BaseEntity {
   @Column({ nullable: true })
   picture: string;
 
+  @Column({ name: 'original_picture', nullable: true })
+  originalPicture: string;
+
   @Column()
   title!: string;
 


### PR DESCRIPTION
…s to s3 #645

1. Added `original_picture` column for backup purpose.
2. Updated migration to:
- Retrieve materials where picture is not referring to s3
- Load pictures from resource
- Upload pictures to s3
- update Material entity
 

Closes #645 